### PR TITLE
Feat/early cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ npm install --save temporarily
 
 There are a [few](https://github.com/vesln/temporary) [other](https://github.com/raszi/node-tmp) [temporary](https://github.com/bruce/node-temp) file creation utilities. Here's why I made my own.
 
-* cleanup by default (on process exit), no opt-out
+* cleanup by default (on process exit), no opt-out (though you may clean up early if necessary)
 * sync by default, meant for testing
 * easy nested dir / file scaffolding with content
 
@@ -88,17 +88,20 @@ All options from **filepath** can be applied as well.
 file();
 // { data: '',
 //   filepath: '/var/folders/30/T/temporarily-RdgC6481',
-//   mode: 438 }
+//   mode: 438,
+//   cleanup: [Function: cleanup] }
 
 file({ mode: 0o777 });
 // { data: '',
 //   filepath: '/var/folders/30/T/temporarily-RdgC6481',
-//   mode: 511 }
+//   mode: 511,
+//   cleanup: [Function: cleanup] }
 
 file({ data: 'Hello World!' }); // write file contents
 // { data: 'Hello World!',
 //   filepath: '/var/folders/30/T/temporarily-RdgC6481',
-//   mode: 438 }
+//   mode: 438,
+//   cleanup: [Function: cleanup] }
 ```
 
 ### dir
@@ -114,15 +117,18 @@ All options from **filepath** can be applied as well.
 ```js
 dir();
 // { filepath: '/var/folders/30/T/temporarily-tkEK6023',
-//   mode: 511 }
+//   mode: 511,
+//   cleanup: [Function: cleanup] }
 
 dir({ dir: os.homedir() });
 // { filepath: '/home/myuser/temporarily-tkEK6023',
-//   mode: 511 }
+//   mode: 511,
+//   cleanup: [Function: cleanup] }
 
 dir({ mode: 0o666 });
 // { filepath: '/var/folders/30/T/temporarily-tkEK6023',
-//   mode: 438 }
+//   mode: 438,
+//   cleanup: [Function: cleanup] }
 
 dir({ name: 'tempo' }, [
   dir([
@@ -132,14 +138,18 @@ dir({ name: 'tempo' }, [
 ])
 // { filepath: '/var/folders/30/T/tempo',
 //   mode: 511,
+//   cleanup: [Function: cleanup],
 //   children:
 //    [ { filepath: '/var/folders/30/T/tempo/temporarily-MwpX5662',
 //        mode: 511,
+//        cleanup: [Function: cleanup],
 //        children:
 //         [ { data: '',
 //             filepath: '/var/folders/30/T/tempo/temporarily-MwpX5662/nestedFile',
-//             mode: 438 } ] },
+//             mode: 438,
+//             cleanup: [Function: cleanup] } ] },
 //      { data: 'Hello World!',
 //        filepath: '/var/folders/30/T/tempo/temporarily-yxYz6104',
-//        mode: 438 } ] }
+//        mode: 438,
+//        cleanup: [Function: cleanup] } ] }
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,7 +33,7 @@ const templateChars = {
   /* eslint-enable id-length */
 };
 
-const tempX = [];
+let tempXCallbacks = [];
 
 // const debug = (...args) => {
 //   console.log(...args);
@@ -76,16 +76,20 @@ const tmpDir = () => path.join(os.tmpdir(), TMP_DIR.replace(TEMPLATE_INTERPOLATE
 
 // exports
 
+export function registerCleanup(fn) {
+  tempXCallbacks.push(fn);
+  return function manualCleanupOne() {
+    fn();
+    tempXCallbacks = tempXCallbacks.filter((callback) => callback !== fn);
+  }
+}
+
 /** */
 export function cleanup() {
-  tempX.forEach((tempFile) => {
-    if (tempFile.isFile) {
-      fs.unlinkSync(tempFile.filepath);
-    } else {
-      fs.rmdirSync(tempFile.filepath);
-    }
+  tempXCallbacks.forEach((fn) => {
+    fn();
   });
-  tempX.length = 0;
+  tempXCallbacks.length = 0;
 }
 
 /**
@@ -130,7 +134,9 @@ export function dir(options = {}, children = []) {
     if (err.code !== 'ENOENT') {
       throw new Error(`Could not check ${tempDir.filepath}.`);
     }
-    tempX.push(tempDir);
+    tempDir.cleanup = registerCleanup(() => {
+      fs.rmdirSync(tempDir.filepath);
+    });
     const parentDir = path.dirname(tempDir.filepath);
     dir({
       dir: path.dirname(parentDir),
@@ -165,7 +171,9 @@ export function file(options = {}) {
     mode,
   };
   const parentDir = path.dirname(tempFile.filepath);
-  tempX.push(tempFile);
+  tempFile.cleanup = registerCleanup(() => {
+    fs.unlinkSync(tempFile.filepath);
+  });
   try {
     fs.accessSync(parentDir, fs.F_OK);
   } catch (err) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -76,7 +76,7 @@ const tmpDir = () => path.join(os.tmpdir(), TMP_DIR.replace(TEMPLATE_INTERPOLATE
 
 // exports
 
-export function registerCleanup(fn) {
+function registerCleanup(fn) {
   tempXCallbacks.push(fn);
   return function manualCleanupOne() {
     fn();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -40,6 +40,15 @@ describe('temporarily', () => {
       expect(() => exists(tempFile1)).toThrow();
       expect(() => exists(tempFile2)).toThrow();
     });
+
+    it('should permit early cleanup', () => {
+      const tempDir1 = dir();
+      const tempDir2 = dir();
+      tempDir2.cleanup();
+      cleanup();
+      expect(() => exists(tempDir1)).toThrow();
+      expect(() => exists(tempDir2)).toThrow();
+    });
   });
 
   describe('dir', () => {
@@ -71,6 +80,14 @@ describe('temporarily', () => {
       });
       expect(read(tempDir.children[1])).toBe('Hello World!');
     });
+
+    it('should permit early cleanup', () => {
+      const tempDir1 = dir();
+      const tempDir2 = dir();
+      tempDir2.cleanup();
+      expect(() => exists(tempDir2)).toThrow();
+      expect(() => exists(tempDir1)).not.toThrow();
+    })
   });
 
   describe('file', () => {
@@ -89,6 +106,14 @@ describe('temporarily', () => {
       const tempFile = file({ data: 'Hello World!' });
       expect(read(tempFile)).toBe('Hello World!');
     });
+
+    it('should permit early cleanup', () => {
+      const tempFile1 = file();
+      const tempFile2 = file();
+      tempFile2.cleanup();
+      expect(() => exists(tempFile2)).toThrow();
+      expect(() => exists(tempFile1)).not.toThrow();
+    })
   });
 
   describe('filepath', () => {


### PR DESCRIPTION
This change adds a function to the return values of `dir()` and `file()`, which permits the consumer to clean up the temporary files early. Original functionality of cleaning up on exit is not affected.

Examples where this might be useful:

- Local testing, where the test process is run with a watch flag. Calling the `cleanup` function would permit each test to be cleaned up after its completion.
- Web server which needs temp working space. Since this is a long-running process, the list of files in the `tempX` array would grow without bound without some way of clearing them.